### PR TITLE
Update Installations.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ And also some additional extensions in config.neon.
 
 ```yml
 extensions:
-    arachne.doctrine: Arachne\Doctrine\DI\DoctrineExtension(%debugMode%)
+    arachne.doctrine: Arachne\Doctrine\DI\DoctrineExtension
     kdyby.console: Kdyby\Console\DI\ConsoleExtension
     kdyby.doctrine: Kdyby\Doctrine\DI\OrmExtension
 ```


### PR DESCRIPTION
Arachne\Doctrine\DI\DoctrineExtension does not have a constructor so it's not possible to pass any arguments to constructor